### PR TITLE
Update to use Relay API tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # relaysh-docker-action
 
-This github action will update and run a relay.sh workflow upon commit to a repo.
+This GitHub Action will update and run a [Relay](https://relay.sh) workflow upon commit to a repository.
 
 ## Usage
 
-To use it, add a GitHub Actions workflow in the repo where you keep your Relay workflows.
+To use it, add a GitHub Actions workflow in the repository where you keep your Relay workflows.
 
 ```yaml
 name: update-and-run-workflow-on-commit
@@ -21,14 +21,9 @@ on:
         fetch-depth: 0
     - uses: puppetlabs/relaysh-docker-update-workflow@main
       with:
-        RELAY_USERNAME: ${{ secrets.RELAY_USERNAME }}
-        RELAY_PASSWORD: ${{ secrets.RELAY_PASSWORD }}
-        # OPTIONAL: see workflow_mappings section below
+        RELAY_API_TOKEN: ${{ secrets.RELAY_API_TOKEN }}
         RELAY_WORKFLOW: "relay-workflow-name"
         RELAY_WORKFLOW_FILE: "relay.yaml"
-        # OPTIONAL: enables pointing the relay CLI at the local dev environment
-        RELAY_HOST_API: "api.relay.sh"
-        RELAY_HOST_UI: "ui.relay.sh"
 ```
 
-The action's behavior is configurable based on the presence of a `workflow_mappings.yaml` configuration file in the root of the repository. This file's purpose is to map filenames inside the repository to workflow names as they exist on the Relay service. As such, it should be a list of maps, each with a `name` and `file` key, where `name` is the user-visible workflow name on the Relay service (i.e. displayed by `relay workflow list`) and `file` is the path and filename of the workflow YAML, relative to the repository root. See the [workflow_mappings.yaml](workflow_mappings.yaml) in this directory for an example.
+The action's behavior is configurable based on the presence of a `workflow_mappings.yaml` configuration file in the root of the repository. This file's purpose is to map filenames inside the repository to workflow names as they exist in Relay. As such, it should be a list of maps, each with a `name` and `file` key, where `name` is the user-visible workflow name in Relay (i.e. displayed by `relay workflow list`) and `file` is the path and filename of the workflow YAML, relative to the repository root. See the [workflow_mappings.yaml](workflow_mappings.yaml) in this directory for an example.

--- a/action.yml
+++ b/action.yml
@@ -1,27 +1,24 @@
-name: 'Updates and runs a relay.sh workflow on commit'
-description: 'This action will update and run a named workflow on the service from github'
+name: 'Updates a Relay workflow on commit'
+description: 'This action will update a named Relay workflow from GitHub'
 inputs:
-  relay_host_api:
-    required: false
-    description: "Relay Host API address"
-  relay_host_ui:
-    required: false
-    description: "Relay Host UI address"
-  relay_username:
+  relay_api_token:
     required: true
-    description: "Username on the relay service (stored as a repo secret)"
-  relay_password:
-    required: true
-    description: "Login password for relay (stored as a repo secret)"
+    description: "Relay API token"
   relay_workflow:
     required: false
     description: "Relay workflow name"
   relay_workflow_file:
     required: false
     description: "Relay workflow file"
-outputs:
-  reponse:
-    description: "response message from the relay service"
+  relay_configuration_file:
+    required: false
+    description: "Relay CLI configuration file"
+  relay_configuration_context:
+    required: false
+    description: "Relay CLI configuration context"
+  relay_configuration_debug:
+    required: false
+    description: "Relay CLI configuration debug"
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
* Update to use Relay API token management
* Removes deprecated options
* Adds new (optional) configuration options for advanced use
* Fixes `add_new_workflow` failure (missing space in "-f" argument)