### PR TITLE
Simplify logic using new 'save' command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
-FROM relaysh/core:latest-python
+FROM python:3-alpine
+
+ARG cli=v4.5.0
+RUN set -eux ; \
+   wget https://github.com/puppetlabs/relay/releases/download/${cli}/relay-${cli}-linux-amd64 && \
+   wget https://github.com/puppetlabs/relay/releases/download/${cli}/relay-${cli}-linux-amd64.sha256 && \
+   echo "$( cat relay-${cli}-linux-amd64.sha256 )  relay-${cli}-linux-amd64" | sha256sum -c - && \
+   mv relay-${cli}-linux-amd64 /usr/local/bin/relay && chmod 755 /usr/local/bin/relay && \
+   rm relay-${cli}-linux-amd64.sha256
+
+RUN pip --no-cache-dir install pyyaml
+
 COPY entrypoint.py /entrypoint.py
 ENTRYPOINT ["/entrypoint.py"]


### PR DESCRIPTION
* Incorporates the new `relay workflow save` command:
  * Removes the complexity of determining whether to "add' or "replace" the workflow file
  * Removes the need to download & compare the previous workflow file
* Adds a streamlined, customized Dockerfile instead of relying on `relaysh/core:latest-python`
  * The `relaysh/core` steps are technically deprecated, and we're likely removing/replacing them.
  * In this case (where breaking changes are concerned), we'd have to be careful about updating the Relay CLI version in the `relaysh/core` steps, as it would potentially break existing user workflows, and this GitHub Action shouldn't be concerned or entangled with that.
  * Also noting for posterity that we are not currently versioning these (or other) steps which would also alleviate this issue to some degree.